### PR TITLE
Fix  two auxiliary stores, renamed collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Our dataset is managed by the DataFrame `glovo-foodi-ml-dataset.csv`. This datas
 * **city_code**: Name of the city where the store is located.
 * **store_name**: Name of the store selling that product. If `store_name` is equal to `AS_XYZ`, it represents an auxiliary store. This means that while the samples contained are for the most part valid, the store name can't be used in learning tasks
 * **product_name**: Name of the product. All products have `product_name`, so this column does not contain any `NaN` value.
-* **collection_name**: Name of the section of the product, used for organizing the store menu. Common values are _"drinks", "our pizzas", "desserts"_. All products have `collection_name` associated to it, so this column does not have any `NaN` value in it.
+* **collection_section**: Name of the section of the product, used for organizing the store menu. Common values are _"drinks", "our pizzas", "desserts"_. All products have `collection_section` associated to it, so this column does not have any `NaN` value in it.
 * **product_description**: A detailed description of the product, describing ingredients and components of it. **Not all products of our data have description, so this column contains `NaN` values that must be removed by the researchers as a preprocessing step.**
 * **subset**: Categorical variable indicating if the sample belongs to the Training, Validation or Test set. The respective values in the DataFrame are `["train", "val", "test"]`. 
 * **HIER**: Boolean variable indicating if the store name can be used to retrieve product information (indicating if the store_name is **not** an auxiliary store (with code `AS_XYZ`)).

--- a/notebooks/FooDI-ML Dataset Stats Analytics.ipynb
+++ b/notebooks/FooDI-ML Dataset Stats Analytics.ipynb
@@ -20,9 +20,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "download: s3://glovo-products-dataset-d1c9720d/language_stats/language_codes_wikipedia.csv to ./language_codes_wikipedia.csv\n",
+      "download: s3://glovo-products-dataset-d1c9720d/language_stats/country_code2name.csv to ./country_code2name.csv\n",
+      "download: s3://glovo-products-dataset-d1c9720d/language_stats/foodi-ml-dataset-language-analytics.csv to ./foodi-ml-dataset-language-analytics.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "!aws s3 cp --recursive s3://glovo-products-dataset-d1c9720d/language_stats/ . --no-sign-request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting numpy==1.19.5\n",
+      "  Downloading numpy-1.19.5-cp38-cp38-macosx_10_9_x86_64.whl (15.6 MB)\n",
+      "\u001b[K     |████████████████████████████████| 15.6 MB 380 kB/s eta 0:00:01    |█████████████████▋              | 8.6 MB 5.3 MB/s eta 0:00:02\n",
+      "\u001b[?25hInstalling collected packages: numpy\n",
+      "  Attempting uninstall: numpy\n",
+      "    Found existing installation: numpy 1.19.2\n",
+      "    Uninstalling numpy-1.19.2:\n",
+      "      Successfully uninstalled numpy-1.19.2\n",
+      "Successfully installed numpy-1.19.5\n",
+      "Collecting pandas==1.2.2\n",
+      "  Downloading pandas-1.2.2-cp38-cp38-macosx_10_9_x86_64.whl (10.5 MB)\n",
+      "\u001b[K     |████████████████████████████████| 10.5 MB 4.8 MB/s eta 0:00:01    |██▊                             | 880 kB 1.3 MB/s eta 0:00:08     |██████████████▌                 | 4.8 MB 1.3 MB/s eta 0:00:05\n",
+      "\u001b[?25hRequirement already satisfied: pytz>=2017.3 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from pandas==1.2.2) (2020.1)\n",
+      "Requirement already satisfied: numpy>=1.16.5 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from pandas==1.2.2) (1.19.5)\n",
+      "Requirement already satisfied: python-dateutil>=2.7.3 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from pandas==1.2.2) (2.8.1)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from python-dateutil>=2.7.3->pandas==1.2.2) (1.15.0)\n",
+      "Installing collected packages: pandas\n",
+      "  Attempting uninstall: pandas\n",
+      "    Found existing installation: pandas 1.1.3\n",
+      "    Uninstalling pandas-1.1.3:\n",
+      "      Successfully uninstalled pandas-1.1.3\n",
+      "Successfully installed pandas-1.2.2\n",
+      "Collecting plotly==5.2.2\n",
+      "  Using cached plotly-5.2.2-py2.py3-none-any.whl (21.8 MB)\n",
+      "Collecting tenacity>=6.2.0\n",
+      "  Downloading tenacity-8.0.1-py3-none-any.whl (24 kB)\n",
+      "Requirement already satisfied: six in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from plotly==5.2.2) (1.15.0)\n",
+      "Installing collected packages: tenacity, plotly\n",
+      "Successfully installed plotly-5.2.2 tenacity-8.0.1\n",
+      "Collecting matplotlib==3.4.2\n",
+      "  Using cached matplotlib-3.4.2-cp38-cp38-macosx_10_9_x86_64.whl (7.2 MB)\n",
+      "Requirement already satisfied: pyparsing>=2.2.1 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from matplotlib==3.4.2) (2.4.7)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from matplotlib==3.4.2) (1.3.0)\n",
+      "Requirement already satisfied: numpy>=1.16 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from matplotlib==3.4.2) (1.19.5)\n",
+      "Requirement already satisfied: pillow>=6.2.0 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from matplotlib==3.4.2) (8.0.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from matplotlib==3.4.2) (2.8.1)\n",
+      "Requirement already satisfied: cycler>=0.10 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from matplotlib==3.4.2) (0.10.0)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/poncpalau/opt/anaconda3/lib/python3.8/site-packages (from python-dateutil>=2.7->matplotlib==3.4.2) (1.15.0)\n",
+      "Installing collected packages: matplotlib\n",
+      "  Attempting uninstall: matplotlib\n",
+      "    Found existing installation: matplotlib 3.3.2\n",
+      "    Uninstalling matplotlib-3.3.2:\n",
+      "      Successfully uninstalled matplotlib-3.3.2\n",
+      "Successfully installed matplotlib-3.4.2\n"
+     ]
+    }
+   ],
    "source": [
     "# Install packages\n",
     "!pip install numpy==1.19.5\n",
@@ -33,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -61,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,46 +140,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Unnamed: 0                int64\n",
-       "country_code             object\n",
-       "city_code                object\n",
-       "store_name               object\n",
-       "product_name             object\n",
-       "product_name_lang1       object\n",
-       "collection_name          object\n",
-       "collection_name_lang1    object\n",
-       "product_description      object\n",
-       "product_descr_lang1      object\n",
-       "hash                      int64\n",
-       "s3_path                  object\n",
-       "subset                   object\n",
-       "aux_store                  bool\n",
-       "HIER                       bool\n",
+       "Unnamed: 0                   int64\n",
+       "country_code                object\n",
+       "city_code                   object\n",
+       "store_name                  object\n",
+       "product_name                object\n",
+       "product_name_lang1          object\n",
+       "collection_section          object\n",
+       "collection_section_lang1    object\n",
+       "product_description         object\n",
+       "product_descr_lang1         object\n",
+       "hash                         int64\n",
+       "s3_path                     object\n",
+       "subset                      object\n",
+       "aux_store                     bool\n",
+       "HIER                          bool\n",
        "dtype: object"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df.dtypes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "# 1. Basic stats"
    ]
   },
   {
@@ -130,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -156,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,17 +236,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"no_collection_name\"] = df.collection_name.isna()\n",
-    "num_collections = df.shape[0] - df[\"no_collection_name\"].sum()"
+    "df[\"no_collection_section\"] = df.collection_section.isna()\n",
+    "num_collections = df.shape[0] - df[\"no_collection_section\"].sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -209,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +287,7 @@
      "output_type": "stream",
      "text": [
       "Products with product name =  2,887,437\n",
-      "Products with collection name =  2,887,437\n",
+      "Products with collection section =  2,887,437\n",
       "Products with product description =  983,482\n",
       "Store names in our dataset =  2,887,444\n",
       "\n",
@@ -237,7 +298,7 @@
    ],
    "source": [
     "print(\"Products with product name = \", \"{:,}\".format(num_product_names))\n",
-    "print(f\"Products with collection name = \", \"{:,}\".format(num_collections))\n",
+    "print(f\"Products with collection section = \", \"{:,}\".format(num_collections))\n",
     "print(f\"Products with product description = \",\"{:,}\".format(df.shape[0]-num_products_no_descr))\n",
     "print(f\"Store names in our dataset = \",\"{:,}\".format(num_stores))\n",
     "print()\n",
@@ -285,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -369,7 +430,7 @@
        "4  American Samoa           AS"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -389,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -410,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -422,7 +483,7 @@
        "       'BR', 'GH', 'NG', 'UY'], dtype=object)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -447,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -466,7 +527,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -480,14 +541,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[93mUnique languages on collection name:\n"
+      "\u001b[93mUnique languages on collection section:\n"
      ]
     },
     {
@@ -499,20 +560,20 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "unique_languages_collection_name = pd.DataFrame(df[\"collection_name_lang1\"].unique())\n",
-    "print(f\"{color.YELLOW}Unique languages on collection name:\")\n",
-    "df[\"collection_name_lang1\"].unique()"
+    "unique_languages_collection_section = pd.DataFrame(df[\"collection_section_lang1\"].unique())\n",
+    "print(f\"{color.YELLOW}Unique languages on collection section:\")\n",
+    "df[\"collection_section_lang1\"].unique()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -531,7 +592,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -544,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -559,7 +620,7 @@
    ],
    "source": [
     "# UNIQUE LANGUAGES\n",
-    "unique_languages = unique_languages_product_name.merge(unique_languages_collection_name, how=\"outer\", on=0).merge(unique_languages_description, how=\"outer\", on=0)\n",
+    "unique_languages = unique_languages_product_name.merge(unique_languages_collection_section, how=\"outer\", on=0).merge(unique_languages_description, how=\"outer\", on=0)\n",
     "num_unique_languages = unique_languages.shape[0]\n",
     "print(f\"{color.YELLOW}################### ABSTRACT INFO ####################{color.END}\")\n",
     "print(f\"{color.GREEN}Number of languages {num_unique_languages}{color.END}\")\n",
@@ -584,7 +645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -615,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -627,17 +688,17 @@
     }
    ],
    "source": [
-    "languages_collect_name_post_filtered = df[\"collection_name_lang1\"].value_counts().to_frame().rename_axis(\"lang_code\").reset_index()\n",
+    "languages_collect_name_post_filtered = df[\"collection_section_lang1\"].value_counts().to_frame().rename_axis(\"lang_code\").reset_index()\n",
     "languages_collect_name_post_filtered = languages_collect_name_post_filtered.merge(lang_code2name, how='inner', on='lang_code')\n",
     "languages_collect_name_post_filtered[\"is_ee_we_lang\"] = languages_collect_name_post_filtered.lang_code.apply(lambda x : True if x in lang_code_countries_ee_we else False)\n",
     "collect_names_ee_we = languages_collect_name_post_filtered[languages_collect_name_post_filtered.is_ee_we_lang == True]\n",
-    "num_collections_ee_we = collect_names_ee_we[\"collection_name_lang1\"].sum()\n",
-    "print(f\"{color.YELLOW}Collections with under represented langs EE = \" ,collect_names_ee_we[\"collection_name_lang1\"].sum())"
+    "num_collections_ee_we = collect_names_ee_we[\"collection_section_lang1\"].sum()\n",
+    "print(f\"{color.YELLOW}Collections with under represented langs EE = \" ,collect_names_ee_we[\"collection_section_lang1\"].sum())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -659,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -692,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -713,16 +774,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataframe_tofill['total_language_ct'] = dataframe_tofill['product_name_lang1']+dataframe_tofill['product_descr_lang1']+dataframe_tofill['collection_name_lang1']"
+    "dataframe_tofill['total_language_ct'] = dataframe_tofill['product_name_lang1']+dataframe_tofill['product_descr_lang1']+dataframe_tofill['collection_section_lang1']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -752,7 +813,7 @@
        "      <th>is_ee_we_lang_x</th>\n",
        "      <th>product_descr_lang1</th>\n",
        "      <th>is_ee_we_lang_y</th>\n",
-       "      <th>collection_name_lang1</th>\n",
+       "      <th>collection_section_lang1</th>\n",
        "      <th>is_ee_we_lang</th>\n",
        "      <th>total_language_ct</th>\n",
        "    </tr>\n",
@@ -895,32 +956,32 @@
        "8        pt              107418          Portuguese            False   \n",
        "9        de               62469              German            False   \n",
        "\n",
-       "   product_descr_lang1 is_ee_we_lang_y  collection_name_lang1  is_ee_we_lang  \\\n",
-       "0              94924.0           False                 594675          False   \n",
-       "1             247467.0           False                 793606          False   \n",
-       "2              94753.0           False                 253388          False   \n",
-       "3             133141.0            True                 151595           True   \n",
-       "4              20777.0            True                 184574           True   \n",
-       "5              79956.0           False                 150500          False   \n",
-       "6              41253.0           False                  99294          False   \n",
-       "7              45403.0           False                 112489          False   \n",
-       "8              61184.0           False                 161768          False   \n",
-       "9               5901.0           False                  53146          False   \n",
+       "   product_descr_lang1 is_ee_we_lang_y  collection_section_lang1  \\\n",
+       "0              94924.0           False                    594675   \n",
+       "1             247467.0           False                    793606   \n",
+       "2              94753.0           False                    253388   \n",
+       "3             133141.0            True                    151595   \n",
+       "4              20777.0            True                    184574   \n",
+       "5              79956.0           False                    150500   \n",
+       "6              41253.0           False                     99294   \n",
+       "7              45403.0           False                    112489   \n",
+       "8              61184.0           False                    161768   \n",
+       "9               5901.0           False                     53146   \n",
        "\n",
-       "   total_language_ct  \n",
-       "0          1554243.0  \n",
-       "1          1587286.0  \n",
-       "2           605581.0  \n",
-       "3           479009.0  \n",
-       "4           392176.0  \n",
-       "5           396602.0  \n",
-       "6           291218.0  \n",
-       "7           279728.0  \n",
-       "8           330370.0  \n",
-       "9           121516.0  "
+       "   is_ee_we_lang  total_language_ct  \n",
+       "0          False          1554243.0  \n",
+       "1          False          1587286.0  \n",
+       "2          False           605581.0  \n",
+       "3           True           479009.0  \n",
+       "4           True           392176.0  \n",
+       "5          False           396602.0  \n",
+       "6          False           291218.0  \n",
+       "7          False           279728.0  \n",
+       "8          False           330370.0  \n",
+       "9          False           121516.0  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -931,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,7 +1004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -952,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1960,9 +2021,9 @@
        }
       },
       "text/html": [
-       "<div>                            <div id=\"99d53637-41af-4289-96a6-d5e2a5a079aa\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"99d53637-41af-4289-96a6-d5e2a5a079aa\")) {                    Plotly.newPlot(                        \"99d53637-41af-4289-96a6-d5e2a5a079aa\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"Language name=%{x}<br>Number of samples=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#FFCC1B\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"Spanish\",\"English\",\"Russian\",\"Ukrainian\",\"Italian\",\"Georgian\",\"Portuguese\",\"Polish\",\"French\",\"Romanian\",\"Bulgarian\",\"German\",\"Croatian\",\"Turkish\",\"Serbian\",\"Catalan\",\"Slovenian\",\"Macedonian\",\"Bosnian\",\"Galician\"],\"xaxis\":\"x\",\"y\":[1587286.0,1554243.0,605581.0,479009.0,396602.0,392176.0,330370.0,291218.0,279728.0,134665.0,133989.0,121516.0,71041.0,68390.0,66944.0,53404.0,48959.0,36912.0,28429.0,25529.0],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"margin\":{\"t\":60},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Language name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Number of samples\"}}},                        {\"toImageButtonOptions\": {\"format\": \"png\", \"filename\": \"custom_image\", \"height\": 525, \"width\": 985, \"scale\": 4}, \"responsive\": true}                    ).then(function(){\n",
+       "<div>                            <div id=\"f26648a5-fbb0-4ddb-8842-080c32149fdf\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"f26648a5-fbb0-4ddb-8842-080c32149fdf\")) {                    Plotly.newPlot(                        \"f26648a5-fbb0-4ddb-8842-080c32149fdf\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"Language name=%{x}<br>Number of samples=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#FFCC1B\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"Spanish\",\"English\",\"Russian\",\"Ukrainian\",\"Italian\",\"Georgian\",\"Portuguese\",\"Polish\",\"French\",\"Romanian\",\"Bulgarian\",\"German\",\"Croatian\",\"Turkish\",\"Serbian\",\"Catalan\",\"Slovenian\",\"Macedonian\",\"Bosnian\",\"Galician\"],\"xaxis\":\"x\",\"y\":[1587286.0,1554243.0,605581.0,479009.0,396602.0,392176.0,330370.0,291218.0,279728.0,134665.0,133989.0,121516.0,71041.0,68390.0,66944.0,53404.0,48959.0,36912.0,28429.0,25529.0],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"margin\":{\"t\":60},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Language name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Number of samples\"}}},                        {\"toImageButtonOptions\": {\"format\": \"png\", \"filename\": \"custom_image\", \"height\": 525, \"width\": 985, \"scale\": 4}, \"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('99d53637-41af-4289-96a6-d5e2a5a079aa');\n",
+       "var gd = document.getElementById('f26648a5-fbb0-4ddb-8842-080c32149fdf');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -2009,7 +2070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2025,7 +2086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2035,7 +2096,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2046,7 +2107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2055,7 +2116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -2085,8 +2146,8 @@
        "      <th>store_name</th>\n",
        "      <th>product_name</th>\n",
        "      <th>product_name_lang1</th>\n",
-       "      <th>collection_name</th>\n",
-       "      <th>collection_name_lang1</th>\n",
+       "      <th>collection_section</th>\n",
+       "      <th>collection_section_lang1</th>\n",
        "      <th>product_description</th>\n",
        "      <th>product_descr_lang1</th>\n",
        "      <th>hash</th>\n",
@@ -2096,14 +2157,14 @@
        "      <th>HIER</th>\n",
        "      <th>no_description</th>\n",
        "      <th>no_product_name</th>\n",
-       "      <th>no_collection_name</th>\n",
+       "      <th>no_collection_section</th>\n",
        "      <th>country_name</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
-       "      <td>1335446</td>\n",
+       "      <td>763</td>\n",
        "      <td>CL</td>\n",
        "      <td>CON</td>\n",
        "      <td>Dari Darkum</td>\n",
@@ -2125,7 +2186,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>24</th>\n",
-       "      <td>1335550</td>\n",
+       "      <td>774</td>\n",
        "      <td>CL</td>\n",
        "      <td>CON</td>\n",
        "      <td>Starbucks</td>\n",
@@ -2151,31 +2212,35 @@
       ],
       "text/plain": [
        "    Unnamed: 0 country_code city_code   store_name  \\\n",
-       "23     1335446           CL       CON  Dari Darkum   \n",
-       "24     1335550           CL       CON    Starbucks   \n",
+       "23         763           CL       CON  Dari Darkum   \n",
+       "24         774           CL       CON    Starbucks   \n",
        "\n",
-       "                              product_name product_name_lang1 collection_name  \\\n",
-       "23  Degustacion de dulces pequeño (5 uds.)                 es         Postres   \n",
-       "24                   Iced Shaked Lemon Tea                 en        Té y más   \n",
+       "                              product_name product_name_lang1  \\\n",
+       "23  Degustacion de dulces pequeño (5 uds.)                 es   \n",
+       "24                   Iced Shaked Lemon Tea                 en   \n",
        "\n",
-       "   collection_name_lang1                                product_description  \\\n",
-       "23                    it  Brownie, guargüero, trufa de chocolate de lech...   \n",
-       "24                    es  Té verde, negro o passion, hielo y suavemente ...   \n",
+       "   collection_section collection_section_lang1  \\\n",
+       "23            Postres                       it   \n",
+       "24           Té y más                       es   \n",
        "\n",
-       "   product_descr_lang1                 hash  \\\n",
-       "23                  es  -592316957397127029   \n",
-       "24                  es  7505344156658775625   \n",
+       "                                  product_description product_descr_lang1  \\\n",
+       "23  Brownie, guargüero, trufa de chocolate de lech...                  es   \n",
+       "24  Té verde, negro o passion, hielo y suavemente ...                  es   \n",
        "\n",
-       "                                   s3_path subset  aux_store  HIER  \\\n",
-       "23  dataset/PWBLRMY_0000946_1197163669.png  train      False  True   \n",
-       "24    dataset/PWBLRMY_0000128_22484953.png  train      False  True   \n",
+       "                   hash                                 s3_path subset  \\\n",
+       "23  -592316957397127029  dataset/PWBLRMY_0000946_1197163669.png  train   \n",
+       "24  7505344156658775625    dataset/PWBLRMY_0000128_22484953.png  train   \n",
        "\n",
-       "    no_description  no_product_name  no_collection_name country_name  \n",
-       "23           False            False               False        Chile  \n",
-       "24           False            False               False        Chile  "
+       "    aux_store  HIER  no_description  no_product_name  no_collection_section  \\\n",
+       "23      False  True           False            False                  False   \n",
+       "24      False  True           False            False                  False   \n",
+       "\n",
+       "   country_name  \n",
+       "23        Chile  \n",
+       "24        Chile  "
       ]
      },
-     "execution_count": 35,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2186,14 +2251,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-36-1e78804f865a>:1: SettingWithCopyWarning:\n",
+      "<ipython-input-35-1e78804f865a>:1: SettingWithCopyWarning:\n",
       "\n",
       "\n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
@@ -2211,7 +2276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2222,7 +2287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2231,7 +2296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2240,7 +2305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -2337,7 +2402,7 @@
        "9                Ora gyros & pizza     14"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2348,7 +2413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -2552,20 +2617,20 @@
           "AS_083",
           "AS_079",
           "AS_108",
-          "Listo!",
           "AS_162",
+          "Listo!",
           "AS_167",
           "AS_136",
           "A Grainha",
-          "AS_077",
           "AS_123",
+          "AS_077",
           "AS_182",
           "SMALL Азия Парк",
           "Super cosmetic Back up",
           "AS_099",
           "AS_042",
-          "AS_154",
           "AS_259",
+          "AS_154",
           "Listo! Licores",
           "Carrefour Draft Kenitra",
           "AS_189",
@@ -2612,8 +2677,8 @@
           "AS_246",
           "SMALL Богенбай Батыра",
           "Glovo  Party",
-          "SMALL Абая",
           "AS_056",
+          "SMALL Абая",
           "AS_142",
           "One bis selma",
           "Papa John's",
@@ -2648,8 +2713,8 @@
           "AS_090",
           "FOOLISH SHOP",
           "ALDI",
-          "Mercado do Bairro",
           "Юбилейный",
+          "Mercado do Bairro",
           "AS_133",
           "Minipreço",
           "Silpo / Сільпо",
@@ -2667,8 +2732,8 @@
           "ZU",
           "Taco Bell",
           "SMALL Райымбека",
-          "Marjane Edited Menu 23/10",
           "AS_186",
+          "Marjane Edited Menu 23/10",
           "Super Mora",
           "Domino's Pizza",
           "AS_175",
@@ -2676,8 +2741,8 @@
           "AS_288",
           "Starbucks®",
           "Epicerie Générale",
-          "AS_261",
           "AS_165",
+          "AS_261",
           "AS_122",
           "AS_117",
           "AS_300",
@@ -2740,18 +2805,18 @@
           "Greek Taste",
           "Wong",
           "Osava",
-          "La Mafia Se Sienta a La Mesa",
           "Don G",
+          "La Mafia Se Sienta a La Mesa",
           "Tottus",
           "Fastwine - Bebidas a domicilio",
           "Whisky House",
           "Pet shop Artur i Badi",
-          "Pizza Hut Delivery",
           "San Martin",
+          "Pizza Hut Delivery",
           "AS_345",
           "AS_281",
-          "Магазин Дар",
           "AS_208",
+          "Магазин Дар",
           "Time-cafe",
           "Moodro city",
           "AS_047",
@@ -2761,9 +2826,9 @@
           "Fiori e piante Città Studi",
           "Conto",
           "AS_044",
-          "Aroma Novi Sad",
           "Soplidan.ge",
           "AS_119",
+          "Aroma Novi Sad",
           "Roadhouse",
           "Foods For You",
           "Sfeir Libanese Cuisine",
@@ -2774,8 +2839,8 @@
           "Grocery Store",
           "AS_305",
           "AS_159",
-          "Sushi Wok",
           "AS_362",
+          "Sushi Wok",
           "Tienda Shell",
           "Berezka",
           "Biogorod.kz",
@@ -2800,9 +2865,9 @@
           "F",
           "Cooperativa FruFru",
           "Froot",
-          "Casta",
           "AS_184",
           "AS_198",
+          "Casta",
           "Pans & Company",
           "SMALL Сатпаева/Ломова",
           "Frozen Shop",
@@ -2810,8 +2875,8 @@
           "Merry Berry",
           "Sushiya / Сушия",
           "AS_147",
-          "Skroz Dobra Pekara",
           "AS_309",
+          "Skroz Dobra Pekara",
           "Kosmo / Космо",
           "Kibanda Express",
           "AS_317",
@@ -2864,8 +2929,8 @@
           "AS_066",
           "AS_252",
           "Etam",
-          "The Box Shop",
           "Moburger / Мобургер",
+          "The Box Shop",
           "Gaghe",
           "Mister Cat",
           "Biblusi*",
@@ -4230,9 +4295,9 @@
        }
       },
       "text/html": [
-       "<div>                            <div id=\"aff1742a-edc3-4c5c-8314-a142d7ad2ce2\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"aff1742a-edc3-4c5c-8314-a142d7ad2ce2\")) {                    Plotly.newPlot(                        \"aff1742a-edc3-4c5c-8314-a142d7ad2ce2\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"store_name=%{x}<br>count=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#636efa\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"AS_005\",\"AS_037\",\"AS_026\",\"Nikora Supermarket\",\"Douglas\",\"Supermercados Delportal\",\"AS_039\",\"Santa Mar\\u00eda\",\"dm\",\"AS_033\",\"AS_051\",\"AS_048\",\"AS_003\",\"Glovo Bakkal\",\"AS_040\",\"AS_028\",\"Carrefour\",\"Europroduct\",\"AS_059\",\"AS_068\",\"Coral Hipermercados\",\"Naivas\",\"AS_022\",\"AS_014\",\"AS_093\",\"AS_091\",\"AS_023\",\"AS_129\",\"AS_034\",\"AS_013\",\"AS_016\",\"Kaufland\",\"AS_045\",\"AS_125\",\"AS_092\",\"AS_078\",\"AS_021\",\"AS_025\",\"AS_089\",\"AS_019\",\"AS_058\",\"AS_061\",\"McDonald's\",\"Maxi Despensa\",\"AS_095\",\"AS_009\",\"AS_144\",\"AS_076\",\"Spar\",\"AS_020\",\"Goodwill\",\"AS_084\",\"Glood\",\"AS_131\",\"AS_000\",\"AS_100\",\"AS_018\",\"AS_008\",\"AS_049\",\"AS_062\",\"AS_102\",\"Gelmarket Surgelati\",\"AS_011\",\"AS_143\",\"Clarel\",\"AS_105\",\"Marjane\",\"KFC\",\"AS_120\",\"AS_072\",\"Subway\",\"Carlos Garden\",\"AS_038\",\"Carrefour Market Panoramique\",\"Furshet / \\u0424\\u0443\\u0440\\u0448\\u0435\\u0442\",\"T\\u00eda\",\"AS_010\",\"AS_070\",\"AS_012\",\"AS_002\",\"AS_001\",\"AS_103\",\"AS_036\",\"Menu Alcohol Pronto\",\"Shoprite Supermarket\",\"Chocolate Land\",\"Burger King\",\"Idea\",\"AS_145\",\"AS_141\",\"AS_150\",\"AS_088\",\"AS_194\",\"Fora / \\u0424\\u041e\\u0420\\u0410\",\"AS_225\",\"AS_075\",\"AS_074\",\"AS_097\",\"AS_111\",\"AS_115\",\"AS_127\",\"AS_057\",\"AS_209\",\"AS_185\",\"Sila BG\",\"AS_082\",\"AS_112\",\"AS_064\",\"Continente\",\"AS_081\",\"Starbucks\",\"AS_200\",\"AS_094\",\"Tu Tienda Galp\",\"AS_015\",\"AS_158\",\"AS_121\",\"AS_046\",\"AS_060\",\"Voli\",\"Carrefour Express\",\"Euro 2020\",\"AS_041\",\"AS_007\",\"AS_114\",\"AS_087\",\"Happy Center\",\"AS_067\",\"AS_031\",\"Pizza Hut\",\"AS_171\",\"AS_096\",\"AS_101\",\"AS_130\",\"AS_151\",\"Natal com a Well's\",\"AS_170\",\"100 Montaditos\",\"AS_055\",\"Kaufland Social\",\"AS_006\",\"Templul Soarelui\",\"AS_052\",\"CARREFOUR\",\"\\u0421\\u0442\\u043e\\u043b\\u0438\\u0447\\u043d\\u044b\\u0439\",\"Well's Super Store\",\"Veritas\",\"AS_032\",\"57380 (BOE)\",\"IKEA Magazinul cu delicatese suedeze\",\"AS_004\",\"AS_126\",\"berna 1101\",\"AS_024\",\"AS_156\",\"AS_109\",\"Hard Rock Cafe\",\"YES!diet\",\"AS_069\",\"AS_035\",\"AS_137\",\"Auchan\",\"LE-SEGA CAFE\",\"Liki24.com\",\"AS_204\",\"SMALL \\u041c\\u0435\\u043d\\u0434\\u0438\\u043a\\u0443\\u043b\\u043e\\u0432\\u0430\",\"Au Moulin Rouge\",\"AS_116\",\"AS_203\",\"Biedronka\",\"Super Market\",\"AS_238\",\"Olare Wine Naivas categorised\",\"IDEA\",\"AS_083\",\"AS_079\",\"AS_108\",\"Listo!\",\"AS_162\",\"AS_167\",\"AS_136\",\"A Grainha\",\"AS_077\",\"AS_123\",\"AS_182\",\"SMALL \\u0410\\u0437\\u0438\\u044f \\u041f\\u0430\\u0440\\u043a\",\"Super cosmetic Back up\",\"AS_099\",\"AS_042\",\"AS_154\",\"AS_259\",\"Listo! Licores\",\"Carrefour Draft Kenitra\",\"AS_189\",\"Supermercado Rey\",\"Navarro Bodeguero\",\"AS_255\",\"cm-cosmetic market\",\"AS_226\",\"Tottus La Serena\",\"SMALL \\u0428\\u0435\\u0432\\u0447\\u0435\\u043d\\u043a\\u043e\",\"Restaurant Rhythm\",\"SMALL \\u0416\\u0430\\u0440\\u043e\\u043a\\u043e\\u0432\\u0430\",\"SMALL \\u0420\\u043e\\u0437\\u044b\\u0431\\u0430\\u043a\\u0438\\u0435\\u0432\\u0430\",\"AS_065\",\"SMALL \\u0416\\u0443\\u0431\\u0430\\u043d\\u043e\\u0432\\u0430\",\"AS_080\",\"AS_217\",\"Aroma\",\"Kiosco 365\",\"AS_053\",\"AS_222\",\"SMALL \\u041a\\u0435\\u043d\\u0435\\u0441\\u0430\\u0440\\u044b\",\"AS_071\",\"SMALL \\u0412\\u0430\\u043b\\u0438\\u0445\\u0430\\u043d\\u043e\\u0432\\u0430\",\"SMALL \\u0422\\u043e\\u043b\\u0435 \\u0431\\u0438\",\"Lonia kopija\",\"AS_178\",\"Draftstore - 2\",\"AS_249\",\"AS_173\",\"Tu Tienda BP\",\"SMALL \\u0414\\u043e\\u0441\\u0442\\u044b\\u043a\",\"Telepizza\",\"Cora Hypermarket\",\"SMALL \\u041c\\u044b\\u043d\\u0431\\u0430\\u0435\\u0432\\u0430\",\"SMALL \\u0428\\u0430\\u0440\\u0438\\u043f\\u043e\\u0432\\u0430\",\"AS_196\",\"AS_232\",\"AMPM\",\"AS_104\",\"SMALL \\u0410\\u0443\\u044d\\u0437\\u043e\\u0432\\u0430\",\"AS_029\",\"Pizzer\\u00eda Carlos\",\"AS_246\",\"SMALL \\u0411\\u043e\\u0433\\u0435\\u043d\\u0431\\u0430\\u0439 \\u0411\\u0430\\u0442\\u044b\\u0440\\u0430\",\"Glovo  Party\",\"SMALL \\u0410\\u0431\\u0430\\u044f\",\"AS_056\",\"AS_142\",\"One bis selma\",\"Papa John's\",\"AS_153\",\"AS_085\",\"AS_169\",\"SMALL \\u0416\\u0438\\u0431\\u0435\\u043a \\u0416\\u043e\\u043b\\u044b\",\"Pronto\",\"AS_107\",\"SMALL \\u0418\\u0441\\u0438\\u043d\\u0430\\u043b\\u0438\\u0435\\u0432\\u0430\",\"AS_212\",\"Wendy's\",\"AS_172\",\"Herbolario72\",\"Mostaza\",\"Walmart\",\"Dunkin'\",\"Old Wild West\",\"Sushi Master\",\"Agro Man\",\"Glovo Party\",\"Macrocenter\",\"Sushi Master / \\u0421\\u0443\\u0448\\u0438 \\u041c\\u0430\\u0441\\u0442\\u0435\\u0440\",\"AS_267\",\"AS_211\",\"AS_215\",\"AS_197\",\"McDonald's\\u00ae\",\"PadThaiWok\",\"Europroduct Call Center\",\"Florida Burger\",\"AS_090\",\"FOOLISH SHOP\",\"ALDI\",\"Mercado do Bairro\",\"\\u042e\\u0431\\u0438\\u043b\\u0435\\u0439\\u043d\\u044b\\u0439\",\"AS_133\",\"Minipre\\u00e7o\",\"Silpo / \\u0421\\u0456\\u043b\\u044c\\u043f\\u043e\",\"AS_128\",\"Tottus Re\\u00f1aca\",\"Afla Market\",\"ZAZ\",\"AS_140\",\"A101\",\"Me\\u015fhur Pide\",\"AS_149\",\"SMALL \\u0422\\u0443\\u0440\\u0430\\u043d\",\"SMALL\",\"Gladne o\\u010di\",\"ZU\",\"Taco Bell\",\"SMALL \\u0420\\u0430\\u0439\\u044b\\u043c\\u0431\\u0435\\u043a\\u0430\",\"Marjane Edited Menu 23/10\",\"AS_186\",\"Super Mora\",\"Domino's Pizza\",\"AS_175\",\"Gruby Benek\",\"AS_288\",\"Starbucks\\u00ae\",\"Epicerie G\\u00e9n\\u00e9rale\",\"AS_261\",\"AS_165\",\"AS_122\",\"AS_117\",\"AS_300\",\"NaturPlus\",\"AS_231\",\"MandaleFruta\",\"AS_161\",\"AS_319\",\"AS_166\",\"Magnum\",\"AS_237\",\"Burger King\\u00ae\",\"AS_190\",\"Back up - Mercado V\\u00edvet ( BUE)\",\"Ginos\",\"\\u0411\\u0430\\u0445\\u0430\\u0440\\u0438\\u043a\\u0430\",\"SMALL \\u0411\\u0435\\u0439\\u0431\\u0438\\u0442\\u0448\\u0438\\u043b\\u0438\\u043a\",\"AS_291\",\"La Sirena\",\"Bacania Constantin\",\"Metro Farmacia\",\"AS_157\",\"KAUFLAND\",\"Meu DIA\",\"SMALL \\u0421\\u0435\\u0439\\u0444\\u0443\\u043b\\u043b\\u0438\\u043d\\u0430\",\"Farm\\u00e1cia Holon\",\"Galp Conveni\\u00eancia\",\"AS_279\",\"AS_266\",\"AS_110\",\"Baluvana Galia / \\u0411\\u0430\\u043b\\u0443\\u0432\\u0430\\u043d\\u0430 \\u0413\\u0430\\u043b\\u044f\",\"AS_113\",\"Mafia\",\"NormaN\",\"bp Wild Bean Cafe\",\"Go Natural\",\"Coffee Boom\",\"El Espa\\u00f1ol\",\"Nakasero Supermarket\",\"Tintilini\\u0107\",\"Celeiro\",\"Farma 24\",\"note!\",\"\\u041c\\u0430\\u0433\\u0430\\u0437\\u0438\\u043d \\u0437\\u0430 \\u0432\\u0438\\u043d\\u043e\",\"Tu Tienda Repsol\",\"Cicala & Catita\",\"Gastronome*\",\" Continente Restaurante\",\"AS_148\",\"SHASHLIKYAN\",\"AS_389\",\"AS_168\",\"Sushi Kushi\",\"Pesto Cafe\",\"carrefour SCs\",\"Librerias Crisol Arequipa\",\"AS_220\",\"AS_247\",\"Melrose\",\"Greek Taste\",\"Wong\",\"Osava\",\"La Mafia Se Sienta a La Mesa\",\"Don G\",\"Tottus\",\"Fastwine - Bebidas a domicilio\",\"Whisky House\",\"Pet shop Artur i Badi\",\"Pizza Hut Delivery\",\"San Martin\",\"AS_345\",\"AS_281\",\"\\u041c\\u0430\\u0433\\u0430\\u0437\\u0438\\u043d \\u0414\\u0430\\u0440\",\"AS_208\",\"Time-cafe\",\"Moodro city\",\"AS_047\",\"AS_206\",\"Tony Roma's\",\"Pomodoro\",\"Fiori e piante Citt\\u00e0 Studi\",\"Conto\",\"AS_044\",\"Aroma Novi Sad\",\"Soplidan.ge\",\"AS_119\",\"Roadhouse\",\"Foods For You\",\"Sfeir Libanese Cuisine\",\"Tottus Kennedy\",\"El S\\u00faper de los Pastores\",\"Puzata Hata / \\u041f\\u0443\\u0437\\u0430\\u0442\\u0430 \\u0425\\u0430\\u0442\\u0430\",\"America Graffiti\",\"Grocery Store\",\"AS_305\",\"AS_159\",\"Sushi Wok\",\"AS_362\",\"Tienda Shell\",\"Berezka\",\"Biogorod.kz\",\"Rossopomodoro\",\"Marilyn S\\u00e1nguches\",\"AS_118\",\"VAPIANO\",\"Tu Tienda Depaso\",\"AS_179\",\"The Winery\",\"DIS Market Novi Sad\",\"DIS Market Ni\\u0161\",\"AS_328\",\"BAMBOO\",\"AS_229\",\"SMALL \\u0416\\u0430\\u043c\\u0431\\u044b\\u043b\\u0430\",\"Sushiclub\",\"Colibri\",\"SMALL  \\u041a\\u0430\\u0442\\u0430\\u0435\\u0432\\u0430\",\"AS_298\",\"AS_164\",\"F\",\"Cooperativa FruFru\",\"Froot\",\"Casta\",\"AS_184\",\"AS_198\",\"Pans & Company\",\"SMALL \\u0421\\u0430\\u0442\\u043f\\u0430\\u0435\\u0432\\u0430/\\u041b\\u043e\\u043c\\u043e\\u0432\\u0430\",\"Frozen Shop\",\"Mercearia do Aviz\",\"Merry Berry\",\"Sushiya / \\u0421\\u0443\\u0448\\u0438\\u044f\",\"AS_147\",\"Skroz Dobra Pekara\",\"AS_309\",\"Kosmo / \\u041a\\u043e\\u0441\\u043c\\u043e\",\"Kibanda Express\",\"AS_317\",\"Farmacia Ferrarini\",\"AS_274\",\"AS_063\",\"AS_205\",\"Clarel.\",\"AS_254\",\"Tottus Providencia\",\"AS_350\",\"AS_284\",\"Spar Call Center\",\"AS_303\",\"U Afanasicha / \\u0423 \\u0410\\u0444\\u0430\\u043d\\u0430\\u0441\\u0438\\u0447\\u0430\",\"SMALL \\u0421\\u0430\\u0442\\u043f\\u0430\\u0435\\u0432\\u0430/\\u041a\\u0430\\u0438\\u0440\\u0431\\u0430\\u0435\\u0432\\u0430\",\"Firmo\",\"C market\",\"AS_163\",\"AS_292\",\"La Gran Familia Mediterr\\u00e1nea by Dani Garc\\u00eda\",\"Frozen by Crystal\",\"Rodilla\",\"Popeyes\",\"AS_349\",\"Mamma Mia\",\"AS_287\",\"Petsev Evcil Hayvanlar D\\u00fcnyas\\u0131\",\"AS_235\",\"AS_354\",\"Vapiano\",\"Conv\\u00e9m - Entregas de Conveni\\u00eancia\",\"Spartan\",\"AS_308\",\"Chili's\",\"Foster's Hollywood\",\"Back up- HOST\",\"Maharaja & Himalaya\",\"Chopstix\",\"Mercado 100 Montaditos y La Sure\\u00f1a\",\"Sushi Shop\",\"Sinko market\",\"AS_176\",\"Social Coffee\",\"BEFeD\",\"Tottus Nataniel\",\"Office 1 Superstore\",\"Camarasa Fruits\",\"Bubble Tea - MisterTea\",\"AS_066\",\"AS_252\",\"Etam\",\"The Box Shop\",\"Moburger / \\u041c\\u043e\\u0431\\u0443\\u0440\\u0433\\u0435\\u0440\",\"Gaghe\",\"Mister Cat\",\"Biblusi*\",\"A Padaria Portuguesa\",\"Hesburger\",\"VIPS\",\"Abu Auf\",\"GROM\",\"100 Montaditos Tapas\"],\"xaxis\":\"x\",\"y\":[53197,37937,22489,22028,21609,21483,21335,20668,20533,18998,18501,18052,17651,16536,16092,15245,15233,15208,14569,14150,13972,13760,12673,12442,11960,11135,11115,10917,10887,10722,10229,10166,9958,9885,9741,9297,8929,8576,8266,8213,8207,8154,8144,7744,7733,7686,7660,7540,7419,7356,7302,7148,7126,7049,7023,6977,6879,6654,6524,6520,6437,6416,6391,6329,6289,6269,6221,6133,5979,5880,5836,5826,5823,5747,5702,5697,5688,5686,5622,5621,5549,5536,5509,5431,5377,5363,5222,4940,4888,4877,4863,4842,4824,4772,4652,4613,4553,4527,4334,4193,4173,4169,4116,4106,4103,4078,4045,4034,4023,3984,3973,3902,3781,3707,3700,3683,3666,3619,3617,3560,3532,3526,3498,3464,3460,3419,3405,3402,3374,3324,3310,3299,3275,3270,3262,3241,3240,3192,3187,3187,3121,3084,3048,2992,2978,2974,2945,2933,2922,2863,2856,2844,2817,2770,2740,2717,2676,2674,2629,2628,2624,2607,2585,2572,2548,2522,2510,2479,2476,2470,2427,2414,2397,2384,2379,2343,2309,2293,2293,2274,2268,2263,2261,2261,2231,2206,2194,2151,2133,2132,2132,2120,2119,2105,2097,2075,2009,2007,2005,2004,1985,1975,1972,1961,1953,1951,1942,1940,1932,1928,1925,1921,1894,1893,1887,1886,1883,1845,1840,1838,1832,1821,1816,1813,1811,1803,1795,1790,1787,1775,1771,1731,1722,1695,1693,1685,1668,1662,1662,1659,1628,1627,1618,1613,1595,1576,1568,1567,1564,1515,1502,1500,1495,1488,1483,1455,1453,1453,1429,1420,1410,1409,1399,1397,1390,1379,1367,1366,1364,1362,1361,1357,1351,1344,1344,1335,1331,1327,1324,1314,1305,1280,1277,1274,1273,1272,1259,1242,1234,1231,1227,1221,1220,1220,1218,1208,1204,1202,1199,1197,1195,1193,1193,1192,1191,1188,1179,1174,1173,1170,1168,1165,1159,1143,1141,1141,1132,1127,1118,1115,1104,1103,1092,1091,1079,1077,1072,1072,1066,1065,1063,1058,1047,1038,1038,1035,1032,1030,1021,1019,1012,1012,1011,1010,1007,1004,999,993,980,976,962,955,949,946,937,934,931,925,924,923,915,914,911,904,894,893,893,892,891,889,884,883,883,875,875,865,865,864,864,862,860,857,854,850,848,843,838,838,838,837,823,822,820,819,814,808,806,800,796,796,796,795,789,787,787,786,784,782,778,777,776,773,773,768,767,765,760,754,751,751,748,747,746,746,743,742,742,742,741,740,735,734,733,730,723,716,716,711,710,709,707,705,703,699,695,691,688,683,680,678,673,672,669,668,667,664,663,662,661,659,659,656,655,649,644,643,640,636,635,634,633,632,632,629,629,628,627,626,620,618,617,614,613,611,610,607,606,601,600,599,599,599,598,596,595,594,593,592,592,590],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"title\":{\"text\":\"Most common store names\"},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"store_name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"count\"}}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "<div>                            <div id=\"1424832b-316a-4a7b-ae46-2c535613a8e3\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"1424832b-316a-4a7b-ae46-2c535613a8e3\")) {                    Plotly.newPlot(                        \"1424832b-316a-4a7b-ae46-2c535613a8e3\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"store_name=%{x}<br>count=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#636efa\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"AS_005\",\"AS_037\",\"AS_026\",\"Nikora Supermarket\",\"Douglas\",\"Supermercados Delportal\",\"AS_039\",\"Santa Mar\\u00eda\",\"dm\",\"AS_033\",\"AS_051\",\"AS_048\",\"AS_003\",\"Glovo Bakkal\",\"AS_040\",\"AS_028\",\"Carrefour\",\"Europroduct\",\"AS_059\",\"AS_068\",\"Coral Hipermercados\",\"Naivas\",\"AS_022\",\"AS_014\",\"AS_093\",\"AS_091\",\"AS_023\",\"AS_129\",\"AS_034\",\"AS_013\",\"AS_016\",\"Kaufland\",\"AS_045\",\"AS_125\",\"AS_092\",\"AS_078\",\"AS_021\",\"AS_025\",\"AS_089\",\"AS_019\",\"AS_058\",\"AS_061\",\"McDonald's\",\"Maxi Despensa\",\"AS_095\",\"AS_009\",\"AS_144\",\"AS_076\",\"Spar\",\"AS_020\",\"Goodwill\",\"AS_084\",\"Glood\",\"AS_131\",\"AS_000\",\"AS_100\",\"AS_018\",\"AS_008\",\"AS_049\",\"AS_062\",\"AS_102\",\"Gelmarket Surgelati\",\"AS_011\",\"AS_143\",\"Clarel\",\"AS_105\",\"Marjane\",\"KFC\",\"AS_120\",\"AS_072\",\"Subway\",\"Carlos Garden\",\"AS_038\",\"Carrefour Market Panoramique\",\"Furshet / \\u0424\\u0443\\u0440\\u0448\\u0435\\u0442\",\"T\\u00eda\",\"AS_010\",\"AS_070\",\"AS_012\",\"AS_002\",\"AS_001\",\"AS_103\",\"AS_036\",\"Menu Alcohol Pronto\",\"Shoprite Supermarket\",\"Chocolate Land\",\"Burger King\",\"Idea\",\"AS_145\",\"AS_141\",\"AS_150\",\"AS_088\",\"AS_194\",\"Fora / \\u0424\\u041e\\u0420\\u0410\",\"AS_225\",\"AS_075\",\"AS_074\",\"AS_097\",\"AS_111\",\"AS_115\",\"AS_127\",\"AS_057\",\"AS_209\",\"AS_185\",\"Sila BG\",\"AS_082\",\"AS_112\",\"AS_064\",\"Continente\",\"AS_081\",\"Starbucks\",\"AS_200\",\"AS_094\",\"Tu Tienda Galp\",\"AS_015\",\"AS_158\",\"AS_121\",\"AS_046\",\"AS_060\",\"Voli\",\"Carrefour Express\",\"Euro 2020\",\"AS_041\",\"AS_007\",\"AS_114\",\"AS_087\",\"Happy Center\",\"AS_067\",\"AS_031\",\"Pizza Hut\",\"AS_171\",\"AS_096\",\"AS_101\",\"AS_130\",\"AS_151\",\"Natal com a Well's\",\"AS_170\",\"100 Montaditos\",\"AS_055\",\"Kaufland Social\",\"AS_006\",\"Templul Soarelui\",\"AS_052\",\"CARREFOUR\",\"\\u0421\\u0442\\u043e\\u043b\\u0438\\u0447\\u043d\\u044b\\u0439\",\"Well's Super Store\",\"Veritas\",\"AS_032\",\"57380 (BOE)\",\"IKEA Magazinul cu delicatese suedeze\",\"AS_004\",\"AS_126\",\"berna 1101\",\"AS_024\",\"AS_156\",\"AS_109\",\"Hard Rock Cafe\",\"YES!diet\",\"AS_069\",\"AS_035\",\"AS_137\",\"Auchan\",\"LE-SEGA CAFE\",\"Liki24.com\",\"AS_204\",\"SMALL \\u041c\\u0435\\u043d\\u0434\\u0438\\u043a\\u0443\\u043b\\u043e\\u0432\\u0430\",\"Au Moulin Rouge\",\"AS_116\",\"AS_203\",\"Biedronka\",\"Super Market\",\"AS_238\",\"Olare Wine Naivas categorised\",\"IDEA\",\"AS_083\",\"AS_079\",\"AS_108\",\"AS_162\",\"Listo!\",\"AS_167\",\"AS_136\",\"A Grainha\",\"AS_123\",\"AS_077\",\"AS_182\",\"SMALL \\u0410\\u0437\\u0438\\u044f \\u041f\\u0430\\u0440\\u043a\",\"Super cosmetic Back up\",\"AS_099\",\"AS_042\",\"AS_259\",\"AS_154\",\"Listo! Licores\",\"Carrefour Draft Kenitra\",\"AS_189\",\"Supermercado Rey\",\"Navarro Bodeguero\",\"AS_255\",\"cm-cosmetic market\",\"AS_226\",\"Tottus La Serena\",\"SMALL \\u0428\\u0435\\u0432\\u0447\\u0435\\u043d\\u043a\\u043e\",\"Restaurant Rhythm\",\"SMALL \\u0416\\u0430\\u0440\\u043e\\u043a\\u043e\\u0432\\u0430\",\"SMALL \\u0420\\u043e\\u0437\\u044b\\u0431\\u0430\\u043a\\u0438\\u0435\\u0432\\u0430\",\"AS_065\",\"SMALL \\u0416\\u0443\\u0431\\u0430\\u043d\\u043e\\u0432\\u0430\",\"AS_080\",\"AS_217\",\"Aroma\",\"Kiosco 365\",\"AS_053\",\"AS_222\",\"SMALL \\u041a\\u0435\\u043d\\u0435\\u0441\\u0430\\u0440\\u044b\",\"AS_071\",\"SMALL \\u0412\\u0430\\u043b\\u0438\\u0445\\u0430\\u043d\\u043e\\u0432\\u0430\",\"SMALL \\u0422\\u043e\\u043b\\u0435 \\u0431\\u0438\",\"Lonia kopija\",\"AS_178\",\"Draftstore - 2\",\"AS_249\",\"AS_173\",\"Tu Tienda BP\",\"SMALL \\u0414\\u043e\\u0441\\u0442\\u044b\\u043a\",\"Telepizza\",\"Cora Hypermarket\",\"SMALL \\u041c\\u044b\\u043d\\u0431\\u0430\\u0435\\u0432\\u0430\",\"SMALL \\u0428\\u0430\\u0440\\u0438\\u043f\\u043e\\u0432\\u0430\",\"AS_196\",\"AS_232\",\"AMPM\",\"AS_104\",\"SMALL \\u0410\\u0443\\u044d\\u0437\\u043e\\u0432\\u0430\",\"AS_029\",\"Pizzer\\u00eda Carlos\",\"AS_246\",\"SMALL \\u0411\\u043e\\u0433\\u0435\\u043d\\u0431\\u0430\\u0439 \\u0411\\u0430\\u0442\\u044b\\u0440\\u0430\",\"Glovo  Party\",\"AS_056\",\"SMALL \\u0410\\u0431\\u0430\\u044f\",\"AS_142\",\"One bis selma\",\"Papa John's\",\"AS_153\",\"AS_085\",\"AS_169\",\"SMALL \\u0416\\u0438\\u0431\\u0435\\u043a \\u0416\\u043e\\u043b\\u044b\",\"Pronto\",\"AS_107\",\"SMALL \\u0418\\u0441\\u0438\\u043d\\u0430\\u043b\\u0438\\u0435\\u0432\\u0430\",\"AS_212\",\"Wendy's\",\"AS_172\",\"Herbolario72\",\"Mostaza\",\"Walmart\",\"Dunkin'\",\"Old Wild West\",\"Sushi Master\",\"Agro Man\",\"Glovo Party\",\"Macrocenter\",\"Sushi Master / \\u0421\\u0443\\u0448\\u0438 \\u041c\\u0430\\u0441\\u0442\\u0435\\u0440\",\"AS_267\",\"AS_211\",\"AS_215\",\"AS_197\",\"McDonald's\\u00ae\",\"PadThaiWok\",\"Europroduct Call Center\",\"Florida Burger\",\"AS_090\",\"FOOLISH SHOP\",\"ALDI\",\"\\u042e\\u0431\\u0438\\u043b\\u0435\\u0439\\u043d\\u044b\\u0439\",\"Mercado do Bairro\",\"AS_133\",\"Minipre\\u00e7o\",\"Silpo / \\u0421\\u0456\\u043b\\u044c\\u043f\\u043e\",\"AS_128\",\"Tottus Re\\u00f1aca\",\"Afla Market\",\"ZAZ\",\"AS_140\",\"A101\",\"Me\\u015fhur Pide\",\"AS_149\",\"SMALL \\u0422\\u0443\\u0440\\u0430\\u043d\",\"SMALL\",\"Gladne o\\u010di\",\"ZU\",\"Taco Bell\",\"SMALL \\u0420\\u0430\\u0439\\u044b\\u043c\\u0431\\u0435\\u043a\\u0430\",\"AS_186\",\"Marjane Edited Menu 23/10\",\"Super Mora\",\"Domino's Pizza\",\"AS_175\",\"Gruby Benek\",\"AS_288\",\"Starbucks\\u00ae\",\"Epicerie G\\u00e9n\\u00e9rale\",\"AS_165\",\"AS_261\",\"AS_122\",\"AS_117\",\"AS_300\",\"NaturPlus\",\"AS_231\",\"MandaleFruta\",\"AS_161\",\"AS_319\",\"AS_166\",\"Magnum\",\"AS_237\",\"Burger King\\u00ae\",\"AS_190\",\"Back up - Mercado V\\u00edvet ( BUE)\",\"Ginos\",\"\\u0411\\u0430\\u0445\\u0430\\u0440\\u0438\\u043a\\u0430\",\"SMALL \\u0411\\u0435\\u0439\\u0431\\u0438\\u0442\\u0448\\u0438\\u043b\\u0438\\u043a\",\"AS_291\",\"La Sirena\",\"Bacania Constantin\",\"Metro Farmacia\",\"AS_157\",\"KAUFLAND\",\"Meu DIA\",\"SMALL \\u0421\\u0435\\u0439\\u0444\\u0443\\u043b\\u043b\\u0438\\u043d\\u0430\",\"Farm\\u00e1cia Holon\",\"Galp Conveni\\u00eancia\",\"AS_279\",\"AS_266\",\"AS_110\",\"Baluvana Galia / \\u0411\\u0430\\u043b\\u0443\\u0432\\u0430\\u043d\\u0430 \\u0413\\u0430\\u043b\\u044f\",\"AS_113\",\"Mafia\",\"NormaN\",\"bp Wild Bean Cafe\",\"Go Natural\",\"Coffee Boom\",\"El Espa\\u00f1ol\",\"Nakasero Supermarket\",\"Tintilini\\u0107\",\"Celeiro\",\"Farma 24\",\"note!\",\"\\u041c\\u0430\\u0433\\u0430\\u0437\\u0438\\u043d \\u0437\\u0430 \\u0432\\u0438\\u043d\\u043e\",\"Tu Tienda Repsol\",\"Cicala & Catita\",\"Gastronome*\",\" Continente Restaurante\",\"AS_148\",\"SHASHLIKYAN\",\"AS_389\",\"AS_168\",\"Sushi Kushi\",\"Pesto Cafe\",\"carrefour SCs\",\"Librerias Crisol Arequipa\",\"AS_220\",\"AS_247\",\"Melrose\",\"Greek Taste\",\"Wong\",\"Osava\",\"Don G\",\"La Mafia Se Sienta a La Mesa\",\"Tottus\",\"Fastwine - Bebidas a domicilio\",\"Whisky House\",\"Pet shop Artur i Badi\",\"San Martin\",\"Pizza Hut Delivery\",\"AS_345\",\"AS_281\",\"AS_208\",\"\\u041c\\u0430\\u0433\\u0430\\u0437\\u0438\\u043d \\u0414\\u0430\\u0440\",\"Time-cafe\",\"Moodro city\",\"AS_047\",\"AS_206\",\"Tony Roma's\",\"Pomodoro\",\"Fiori e piante Citt\\u00e0 Studi\",\"Conto\",\"AS_044\",\"Soplidan.ge\",\"AS_119\",\"Aroma Novi Sad\",\"Roadhouse\",\"Foods For You\",\"Sfeir Libanese Cuisine\",\"Tottus Kennedy\",\"El S\\u00faper de los Pastores\",\"Puzata Hata / \\u041f\\u0443\\u0437\\u0430\\u0442\\u0430 \\u0425\\u0430\\u0442\\u0430\",\"America Graffiti\",\"Grocery Store\",\"AS_305\",\"AS_159\",\"AS_362\",\"Sushi Wok\",\"Tienda Shell\",\"Berezka\",\"Biogorod.kz\",\"Rossopomodoro\",\"Marilyn S\\u00e1nguches\",\"AS_118\",\"VAPIANO\",\"Tu Tienda Depaso\",\"AS_179\",\"The Winery\",\"DIS Market Novi Sad\",\"DIS Market Ni\\u0161\",\"AS_328\",\"BAMBOO\",\"AS_229\",\"SMALL \\u0416\\u0430\\u043c\\u0431\\u044b\\u043b\\u0430\",\"Sushiclub\",\"Colibri\",\"SMALL  \\u041a\\u0430\\u0442\\u0430\\u0435\\u0432\\u0430\",\"AS_298\",\"AS_164\",\"F\",\"Cooperativa FruFru\",\"Froot\",\"AS_184\",\"AS_198\",\"Casta\",\"Pans & Company\",\"SMALL \\u0421\\u0430\\u0442\\u043f\\u0430\\u0435\\u0432\\u0430/\\u041b\\u043e\\u043c\\u043e\\u0432\\u0430\",\"Frozen Shop\",\"Mercearia do Aviz\",\"Merry Berry\",\"Sushiya / \\u0421\\u0443\\u0448\\u0438\\u044f\",\"AS_147\",\"AS_309\",\"Skroz Dobra Pekara\",\"Kosmo / \\u041a\\u043e\\u0441\\u043c\\u043e\",\"Kibanda Express\",\"AS_317\",\"Farmacia Ferrarini\",\"AS_274\",\"AS_063\",\"AS_205\",\"Clarel.\",\"AS_254\",\"Tottus Providencia\",\"AS_350\",\"AS_284\",\"Spar Call Center\",\"AS_303\",\"U Afanasicha / \\u0423 \\u0410\\u0444\\u0430\\u043d\\u0430\\u0441\\u0438\\u0447\\u0430\",\"SMALL \\u0421\\u0430\\u0442\\u043f\\u0430\\u0435\\u0432\\u0430/\\u041a\\u0430\\u0438\\u0440\\u0431\\u0430\\u0435\\u0432\\u0430\",\"Firmo\",\"C market\",\"AS_163\",\"AS_292\",\"La Gran Familia Mediterr\\u00e1nea by Dani Garc\\u00eda\",\"Frozen by Crystal\",\"Rodilla\",\"Popeyes\",\"AS_349\",\"Mamma Mia\",\"AS_287\",\"Petsev Evcil Hayvanlar D\\u00fcnyas\\u0131\",\"AS_235\",\"AS_354\",\"Vapiano\",\"Conv\\u00e9m - Entregas de Conveni\\u00eancia\",\"Spartan\",\"AS_308\",\"Chili's\",\"Foster's Hollywood\",\"Back up- HOST\",\"Maharaja & Himalaya\",\"Chopstix\",\"Mercado 100 Montaditos y La Sure\\u00f1a\",\"Sushi Shop\",\"Sinko market\",\"AS_176\",\"Social Coffee\",\"BEFeD\",\"Tottus Nataniel\",\"Office 1 Superstore\",\"Camarasa Fruits\",\"Bubble Tea - MisterTea\",\"AS_066\",\"AS_252\",\"Etam\",\"Moburger / \\u041c\\u043e\\u0431\\u0443\\u0440\\u0433\\u0435\\u0440\",\"The Box Shop\",\"Gaghe\",\"Mister Cat\",\"Biblusi*\",\"A Padaria Portuguesa\",\"Hesburger\",\"VIPS\",\"Abu Auf\",\"GROM\",\"100 Montaditos Tapas\"],\"xaxis\":\"x\",\"y\":[53197,37937,22489,22028,21609,21483,21335,20668,20533,18998,18501,18052,17651,16536,16092,15245,15233,15208,14569,14150,13972,13760,12673,12442,11960,11135,11115,10917,10887,10722,10229,10166,9958,9885,9741,9297,8929,8576,8266,8213,8207,8154,8144,7744,7733,7686,7660,7540,7419,7356,7302,7148,7126,7049,7023,6977,6879,6654,6524,6520,6437,6416,6391,6329,6289,6269,6221,6133,5979,5880,5836,5826,5823,5747,5702,5697,5688,5686,5622,5621,5549,5536,5509,5431,5377,5363,5222,4940,4888,4877,4863,4842,4824,4772,4652,4613,4553,4527,4334,4193,4173,4169,4116,4106,4103,4078,4045,4034,4023,3984,3973,3902,3781,3707,3700,3683,3666,3619,3617,3560,3532,3526,3498,3464,3460,3419,3405,3402,3374,3324,3310,3299,3275,3270,3262,3241,3240,3192,3187,3187,3121,3084,3048,2992,2978,2974,2945,2933,2922,2863,2856,2844,2817,2770,2740,2717,2676,2674,2629,2628,2624,2607,2585,2572,2548,2522,2510,2479,2476,2470,2427,2414,2397,2384,2379,2343,2309,2293,2293,2274,2268,2263,2261,2261,2231,2206,2194,2151,2133,2132,2132,2120,2119,2105,2097,2075,2009,2007,2005,2004,1985,1975,1972,1961,1953,1951,1942,1940,1932,1928,1925,1921,1894,1893,1887,1886,1883,1845,1840,1838,1832,1821,1816,1813,1811,1803,1795,1790,1787,1775,1771,1731,1722,1695,1693,1685,1668,1662,1662,1659,1628,1627,1618,1613,1595,1576,1568,1567,1564,1515,1502,1500,1495,1488,1483,1455,1453,1453,1429,1420,1410,1409,1399,1397,1390,1379,1367,1366,1364,1362,1361,1357,1351,1344,1344,1335,1331,1327,1324,1314,1305,1280,1277,1274,1273,1272,1259,1242,1234,1231,1227,1221,1220,1220,1218,1208,1204,1202,1199,1197,1195,1193,1193,1192,1191,1188,1179,1174,1173,1170,1168,1165,1159,1143,1141,1141,1132,1127,1118,1115,1104,1103,1092,1091,1079,1077,1072,1072,1066,1065,1063,1058,1047,1038,1038,1035,1032,1030,1021,1019,1012,1012,1011,1010,1007,1004,999,993,980,976,962,955,949,946,937,934,931,925,924,923,915,914,911,904,894,893,893,892,891,889,884,883,883,875,875,865,865,864,864,862,860,857,854,850,848,843,838,838,838,837,823,822,820,819,814,808,806,800,796,796,796,795,789,787,787,786,784,782,778,777,776,773,773,768,767,765,760,754,751,751,748,747,746,746,743,742,742,742,741,740,735,734,733,730,723,716,716,711,710,709,707,705,703,699,695,691,688,683,680,678,673,672,669,668,667,664,663,662,661,659,659,656,655,649,644,643,640,636,635,634,633,632,632,629,629,628,627,626,620,618,617,614,613,611,610,607,606,601,600,599,599,599,598,596,595,594,593,592,592,590],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"title\":{\"text\":\"Most common store names\"},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"store_name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"count\"}}},                        {\"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('aff1742a-edc3-4c5c-8314-a142d7ad2ce2');\n",
+       "var gd = document.getElementById('1424832b-316a-4a7b-ae46-2c535613a8e3');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -4277,7 +4342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -4333,7 +4398,7 @@
        "  Chau Lao                          25"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4348,7 +4413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4357,7 +4422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4366,153 +4431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Store name</th>\n",
-       "      <th>Number of samples</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>\\tКитайски ресторант (Черковна)</td>\n",
-       "      <td>25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>24 Grill</td>\n",
-       "      <td>28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Chau Lao</td>\n",
-       "      <td>25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Conflict Burger</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>El Dandy Risto &amp; Arepas Bar</td>\n",
-       "      <td>51</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38078</th>\n",
-       "      <td>شاورما مازن الشامي</td>\n",
-       "      <td>47</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38079</th>\n",
-       "      <td>شورما دمشقي</td>\n",
-       "      <td>13</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38080</th>\n",
-       "      <td>ماسة الشام</td>\n",
-       "      <td>13</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38081</th>\n",
-       "      <td>مشاوي وشاورما عروس الشام</td>\n",
-       "      <td>81</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38082</th>\n",
-       "      <td>مطعم عروس دمشق</td>\n",
-       "      <td>28</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>38083 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                            Store name  Number of samples\n",
-       "0      \\tКитайски ресторант (Черковна)                 25\n",
-       "1                             24 Grill                 28\n",
-       "2                             Chau Lao                 25\n",
-       "3                      Conflict Burger                  3\n",
-       "4          El Dandy Risto & Arepas Bar                 51\n",
-       "...                                ...                ...\n",
-       "38078               شاورما مازن الشامي                 47\n",
-       "38079                      شورما دمشقي                 13\n",
-       "38080                       ماسة الشام                 13\n",
-       "38081         مشاوي وشاورما عروس الشام                 81\n",
-       "38082                   مطعم عروس دمشق                 28\n",
-       "\n",
-       "[38083 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "percentage_per_store_renamed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "percentage_per_store_renamed=percentage_per_store_renamed.rename(columns={'store_name':'Store name'})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['Store name', 'Number of samples'], dtype='object')"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "percentage_per_store_renamed.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -5481,9 +5400,9 @@
        }
       },
       "text/html": [
-       "<div>                            <div id=\"ccb4ff0c-3008-40ea-9387-e260cf082bcf\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"ccb4ff0c-3008-40ea-9387-e260cf082bcf\")) {                    Plotly.newPlot(                        \"ccb4ff0c-3008-40ea-9387-e260cf082bcf\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"Store name=%{x}<br>Number of samples=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#FFCC1B\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"Nikora Supermarket\",\"Douglas\",\"Supermercados Delportal\",\"Santa Mar\\u00eda\",\"dm\",\"Glovo Bakkal\",\"Carrefour\",\"Europroduct\",\"Coral Hipermercados\",\"Naivas\",\"Kaufland\",\"McDonald's\",\"Maxi Despensa\",\"Spar\",\"Goodwill\",\"Glood\",\"Gelmarket Surgelati\",\"Clarel\",\"Marjane\",\"KFC\",\"Subway\",\"Carlos Garden\",\"Carrefour Market Panoramique\",\"Furshet / \\u0424\\u0443\\u0440\\u0448\\u0435\\u0442\",\"T\\u00eda\",\"Menu Alcohol Pronto\",\"Shoprite Supermarket\",\"Chocolate Land\",\"Burger King\",\"Idea\",\"Fora / \\u0424\\u041e\\u0420\\u0410\",\"Sila BG\",\"Continente\",\"Starbucks\",\"Tu Tienda Galp\",\"Voli\",\"Carrefour Express\",\"Euro 2020\",\"Happy Center\",\"Pizza Hut\"],\"xaxis\":\"x\",\"y\":[22028,21609,21483,20668,20533,16536,15233,15208,13972,13760,10166,8144,7744,7419,7302,7126,6416,6289,6221,6133,5836,5826,5747,5702,5697,5431,5377,5363,5222,4940,4772,4103,4023,3973,3707,3560,3532,3526,3405,3324],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"margin\":{\"t\":60},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Store name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Number of samples\"}}},                        {\"toImageButtonOptions\": {\"format\": \"png\", \"filename\": \"custom_image\", \"height\": 525, \"width\": 985, \"scale\": 4}, \"responsive\": true}                    ).then(function(){\n",
+       "<div>                            <div id=\"877f73b6-afa4-4b7b-85a7-2ab2f4d6f74b\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"877f73b6-afa4-4b7b-85a7-2ab2f4d6f74b\")) {                    Plotly.newPlot(                        \"877f73b6-afa4-4b7b-85a7-2ab2f4d6f74b\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"Store name=%{x}<br>Number of samples=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#FFCC1B\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"Nikora Supermarket\",\"Douglas\",\"Supermercados Delportal\",\"Santa Mar\\u00eda\",\"dm\",\"Glovo Bakkal\",\"Carrefour\",\"Europroduct\",\"Coral Hipermercados\",\"Naivas\",\"Kaufland\",\"McDonald's\",\"Maxi Despensa\",\"Spar\",\"Goodwill\",\"Glood\",\"Gelmarket Surgelati\",\"Clarel\",\"Marjane\",\"KFC\",\"Subway\",\"Carlos Garden\",\"Carrefour Market Panoramique\",\"Furshet / \\u0424\\u0443\\u0440\\u0448\\u0435\\u0442\",\"T\\u00eda\",\"Menu Alcohol Pronto\",\"Shoprite Supermarket\",\"Chocolate Land\",\"Burger King\",\"Idea\",\"Fora / \\u0424\\u041e\\u0420\\u0410\",\"Sila BG\",\"Continente\",\"Starbucks\",\"Tu Tienda Galp\",\"Voli\",\"Carrefour Express\",\"Euro 2020\",\"Happy Center\",\"Pizza Hut\"],\"xaxis\":\"x\",\"y\":[22028,21609,21483,20668,20533,16536,15233,15208,13972,13760,10166,8144,7744,7419,7302,7126,6416,6289,6221,6133,5836,5826,5747,5702,5697,5431,5377,5363,5222,4940,4772,4103,4023,3973,3707,3560,3532,3526,3405,3324],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"margin\":{\"t\":60},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Store name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Number of samples\"}}},                        {\"toImageButtonOptions\": {\"format\": \"png\", \"filename\": \"custom_image\", \"height\": 525, \"width\": 985, \"scale\": 4}, \"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('ccb4ff0c-3008-40ea-9387-e260cf082bcf');\n",
+       "var gd = document.getElementById('877f73b6-afa4-4b7b-85a7-2ab2f4d6f74b');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -5522,6 +5441,7 @@
     "    'scale': 4 # Multiply title/legend/axis/canvas sizes by this factor\n",
     "  }\n",
     "}\n",
+    "\n",
     "fig = px.bar(percentage_per_store_renamed.sort_values('Number of samples',ascending=False)[:40], x=\"Store name\", y=\"Number of samples\", \n",
     "            log_y=False,color_discrete_sequence=[\"#FFCC1B\"])\n",
     "fig.show(config=config)"
@@ -5536,7 +5456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5546,7 +5466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -5772,7 +5692,7 @@
        "Uruguay                          0.775956"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5783,7 +5703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5792,7 +5712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5801,7 +5721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 49,
    "metadata": {
     "tags": []
    },
@@ -6752,9 +6672,9 @@
        }
       },
       "text/html": [
-       "<div>                            <div id=\"ce75a121-1631-4847-a406-c62782de1898\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"ce75a121-1631-4847-a406-c62782de1898\")) {                    Plotly.newPlot(                        \"ce75a121-1631-4847-a406-c62782de1898\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"Country name=%{x}<br>% with description=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#FFCC1B\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"Moldova\",\"Slovenia\",\"Puerto Rico\",\"Romania\",\"France [l]\",\"Dominican Republic\",\"Ukraine\",\"Nigeria\",\"Bulgaria\",\"Brazil\",\"Italy\",\"Serbia\",\"Honduras\",\"Ghana\",\"Kyrgyzstan\",\"Egypt\",\"Panama\",\"Portugal\",\"Kazakhstan\",\"Bosnia and Herzegovina\",\"Costa Rica\",\"Poland\",\"Morocco\",\"Guatemala\",\"C\\u00f4te d'Ivoire [h]\",\"Spain\",\"Croatia\",\"Uganda\",\"Uruguay\",\"Ecuador\"],\"xaxis\":\"x\",\"y\":[0.805714630176623,0.7984071027549289,0.6754966887417219,0.6668756220546913,0.664897381457891,0.6116691600769395,0.5838164817855827,0.5755395683453237,0.5690287972896668,0.5580633740485041,0.546319058947925,0.5136743675679544,0.5009200283085633,0.47197231833910036,0.45921901528013587,0.4562279060095654,0.4405545318943581,0.3795919433973358,0.3743048887294368,0.36381709741550694,0.36371740583909073,0.3128258765493771,0.3064856550046505,0.29322090685727054,0.28808220434875687,0.28057002868932424,0.2794977377865894,0.2667389091386727,0.22404371584699456,0.19489895470383278],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"margin\":{\"t\":60},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Country name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"% with description\"}}},                        {\"toImageButtonOptions\": {\"format\": \"png\", \"filename\": \"custom_image\", \"height\": 525, \"width\": 985, \"scale\": 4}, \"responsive\": true}                    ).then(function(){\n",
+       "<div>                            <div id=\"1ab7b711-011e-4333-915e-63680a50ba14\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"1ab7b711-011e-4333-915e-63680a50ba14\")) {                    Plotly.newPlot(                        \"1ab7b711-011e-4333-915e-63680a50ba14\",                        [{\"alignmentgroup\":\"True\",\"hovertemplate\":\"Country name=%{x}<br>% with description=%{y}<extra></extra>\",\"legendgroup\":\"\",\"marker\":{\"color\":\"#FFCC1B\",\"pattern\":{\"shape\":\"\"}},\"name\":\"\",\"offsetgroup\":\"\",\"orientation\":\"v\",\"showlegend\":false,\"textposition\":\"auto\",\"type\":\"bar\",\"x\":[\"Moldova\",\"Slovenia\",\"Puerto Rico\",\"Romania\",\"France [l]\",\"Dominican Republic\",\"Ukraine\",\"Nigeria\",\"Bulgaria\",\"Brazil\",\"Italy\",\"Serbia\",\"Honduras\",\"Ghana\",\"Kyrgyzstan\",\"Egypt\",\"Panama\",\"Portugal\",\"Kazakhstan\",\"Bosnia and Herzegovina\",\"Costa Rica\",\"Poland\",\"Morocco\",\"Guatemala\",\"C\\u00f4te d'Ivoire [h]\",\"Spain\",\"Croatia\",\"Uganda\",\"Uruguay\",\"Ecuador\"],\"xaxis\":\"x\",\"y\":[0.805714630176623,0.7984071027549289,0.6754966887417219,0.6668756220546913,0.664897381457891,0.6116691600769395,0.5838164817855827,0.5755395683453237,0.5690287972896668,0.5580633740485041,0.546319058947925,0.5136743675679544,0.5009200283085633,0.47197231833910036,0.45921901528013587,0.4562279060095654,0.4405545318943581,0.3795919433973358,0.3743048887294368,0.36381709741550694,0.36371740583909073,0.3128258765493771,0.3064856550046505,0.29322090685727054,0.28808220434875687,0.28057002868932424,0.2794977377865894,0.2667389091386727,0.22404371584699456,0.19489895470383278],\"yaxis\":\"y\"}],                        {\"barmode\":\"relative\",\"legend\":{\"tracegroupgap\":0},\"margin\":{\"t\":60},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"Country name\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"% with description\"}}},                        {\"toImageButtonOptions\": {\"format\": \"png\", \"filename\": \"custom_image\", \"height\": 525, \"width\": 985, \"scale\": 4}, \"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('ce75a121-1631-4847-a406-c62782de1898');\n",
+       "var gd = document.getElementById('1ab7b711-011e-4333-915e-63680a50ba14');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -6812,7 +6732,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6823,7 +6743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -6844,7 +6764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -6865,7 +6785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -6886,7 +6806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -6907,7 +6827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -6921,14 +6841,14 @@
     }
    ],
    "source": [
-    "print(f\"{color.GREEN} Training unique coll sections = \", len(training_set.collection_name.unique()))\n",
-    "print(f\"{color.YELLOW}Validation unique coll sections = \", len(validation_set.collection_name.unique()))\n",
-    "print(f\"{color.GREEN}Test unique unique coll sections = \", len(test_set.collection_name.unique()))"
+    "print(f\"{color.GREEN} Training unique coll sections = \", len(training_set.collection_section.unique()))\n",
+    "print(f\"{color.YELLOW}Validation unique coll sections = \", len(validation_set.collection_section.unique()))\n",
+    "print(f\"{color.GREEN}Test unique unique coll sections = \", len(test_set.collection_section.unique()))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -6949,7 +6869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -6971,9 +6891,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "itag_env_2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "itag_env_2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -6985,7 +6905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is opened in order to:
* Fix two auxiliary stores that were not categorised as auxiliary store. Thus, two new auxiliary stores are added `AS_703, AS_704`.
* Rename collection_name to collection_section following the nomenclature of the paper.
* Updated the notebook `notebooks/FooDI-ML Dataset Stats Analytics.ipynb` with the new changes.
* Also both the dataframes listed below have been updated with the information listed above.
    * glovo-foodi-ml-dataset.csv
    * foodi-ml-dataset-language-analytics.csv
    